### PR TITLE
[BUGFIX] URL-Encode the project name

### DIFF
--- a/lib/gergich.rb
+++ b/lib/gergich.rb
@@ -79,7 +79,7 @@ module Gergich
 
     def change_id
       if info[:project] && info[:branch]
-        "#{info[:project]}~#{ERB::Util.url_encode info[:branch]}~#{info[:change_id]}"
+        "#{ERB::Util.url_encode info[:project]}~#{ERB::Util.url_encode info[:branch]}~#{info[:change_id]}"
       else
         info[:change_id]
       end

--- a/spec/gergich_spec.rb
+++ b/spec/gergich_spec.rb
@@ -62,14 +62,14 @@ RSpec.describe Gergich::Commit do
   end
 
   describe "#change_id" do
-    it "supports branches with slashes" do
+    it "supports branches and project names with slashes" do
       allow(ENV).to receive(:[]).with("GERRIT_PATCHSET_REVISION").and_return("commit-ish")
-      allow(ENV).to receive(:[]).with("GERRIT_PROJECT").and_return("spec-project")
+      allow(ENV).to receive(:[]).with("GERRIT_PROJECT").and_return("namespace/spec-project")
       allow(ENV).to receive(:[]).with("GERRIT_BRANCH").and_return("releases/2017.11.17")
       allow(ENV).to receive(:[]).with("GERRIT_CHANGE_ID").and_return("dummychangeset")
 
       expect(described_class.new.change_id) # %2F = / and %7E = ~
-        .to match("spec-project~releases%2F2017.11.17~dummychangeset")
+        .to match("namespace%2Fspec-project~releases%2F2017.11.17~dummychangeset")
     end
   end
 end


### PR DESCRIPTION
The project name (ENV var GERRIT_PROJECT) is taken to construct Gerrit API calls. However it was not URL-encoded, which meant that characters like '/' (example: GERRIT_PROJECT='some/project/name') were not escaped from the URL, rendering the API URL corrupt in effect.